### PR TITLE
Fix index out of range error on DynamoDB ARN parse

### DIFF
--- a/lambdaguard/utils/arnparse.py
+++ b/lambdaguard/utils/arnparse.py
@@ -49,7 +49,8 @@ def arnparse(arn_str):
     if service not in ['sns', 'apigateway']:
         if service == 'dynamodb':
             resource_type = elements[5].split('/')[0]  # table
-            resource = elements[5].split('/')[1]  # table name
+            if len(elements[5].split('/')) > 1:
+                resource = elements[5].split('/')[1]  # table name
         elif service == 's3':
             if len(elements[5].split('/')) > 1:
                 resource_type = elements[5].split('/', 1)[1]  # objects


### PR DESCRIPTION
Came across an Improperly formed ARN:  `arn:aws:dynamodb:::${Table}`

While not "valid", is allowed in a IAM Policy. This fix prevents an `IndexError: list index out of range` error.