### PR TITLE
Improve public APIGateway detection

### DIFF
--- a/lambdaguard/__version__.py
+++ b/lambdaguard/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (2, 3, 8)
+VERSION = (2, 3, 9)
 
 __version__ = ".".join(map(str, VERSION))

--- a/lambdaguard/core/APIGateway.py
+++ b/lambdaguard/core/APIGateway.py
@@ -27,6 +27,8 @@ class APIGateway(AWS):
         self.resources = []
 
         self.get_api()
+        from pprint import pprint
+        pprint(self.resources)
 
         self.info = f'REST API ID: {self.rest_api_id}'
 

--- a/lambdaguard/core/APIGateway.py
+++ b/lambdaguard/core/APIGateway.py
@@ -27,8 +27,6 @@ class APIGateway(AWS):
         self.resources = []
 
         self.get_api()
-        from pprint import pprint
-        pprint(self.resources)
 
         self.info = f'REST API ID: {self.rest_api_id}'
 

--- a/lambdaguard/security/Public.py
+++ b/lambdaguard/security/Public.py
@@ -23,10 +23,16 @@ class Public:
             if self.item.policy:
                 return
 
-            # Check if API KEY is required for all resources
+            apiKeyRequired = False
+            authorizationType = None
             for res in self.item.resources:
-                if not res['apiKeyRequired']:
-                    yield {
-                        'level': 'high',
-                        'text': 'Service is publicly accessible due to missing Resource-based policy'
-                    }
+                if res['apiKeyRequired']:
+                    apiKeyRequired = True
+                if res['authorizationType'] != 'NONE':
+                    authorizationType = res['authorizationType']
+
+            if not apiKeyRequired and not authorizationType:
+                yield {
+                    'level': 'high',
+                    'text': 'Service is publicly accessible due to missing Resource-based policy'
+                }

--- a/lambdaguard/security/Public.py
+++ b/lambdaguard/security/Public.py
@@ -19,9 +19,14 @@ class Public:
         self.item = item
 
     def audit(self):
-        if self.item.arn.service in ['apigateway']:
-            if not self.item.policy:
-                yield {
-                    'level': 'high',
-                    'text': 'Service is publicly accessible due to missing Resource-based policy'
-                }
+        if self.item.arn.service == 'apigateway':
+            if self.item.policy:
+                return
+
+            # Check if API KEY is required for all resources
+            for res in self.item.resources:
+                if not res['apiKeyRequired']:
+                    yield {
+                        'level': 'high',
+                        'text': 'Service is publicly accessible due to missing Resource-based policy'
+                    }

--- a/tests/unit/security/test_Public.py
+++ b/tests/unit/security/test_Public.py
@@ -48,3 +48,9 @@ class Test(unittest.TestCase):
         obj.resources = [{'id': '0', 'method': 'GET', 'path': '/', 'apiKeyRequired': True, 'authorizationType': 'NONE'}]
         with self.assertRaises(expected):
             next(Public(obj).audit())
+
+        # No policy and Authorization Type set
+        expected = StopIteration
+        obj.resources = [{'id': '0', 'method': 'GET', 'path': '/', 'apiKeyRequired': False, 'authorizationType': 'AWS_IAM'}]
+        with self.assertRaises(expected):
+            next(Public(obj).audit())

--- a/tests/unit/security/test_Public.py
+++ b/tests/unit/security/test_Public.py
@@ -32,9 +32,19 @@ class Test(unittest.TestCase):
             next(Public(obj).audit())
 
     def test_public(self):
-        arn = 'arn:aws:execute-api:eu-west-1:0:id/stage/method/path'
+        obj = APIGateway('arn:aws:execute-api:eu-west-1:0:id/stage/method/path')
+
+        # No policy and API Key not required
         expected = {
             'level': 'high',
             'text': 'Service is publicly accessible due to missing Resource-based policy'
         }
-        self.assertEqual(expected, next(Public(APIGateway(arn)).audit()))
+        obj.policy = {}
+        obj.resources = [{'id': '0', 'method': 'GET', 'path': '/', 'apiKeyRequired': False, 'authorizationType': 'NONE'}]
+        self.assertEqual(expected, next(Public(obj).audit()))
+
+        # No policy and API Key required
+        expected = StopIteration
+        obj.resources = [{'id': '0', 'method': 'GET', 'path': '/', 'apiKeyRequired': True, 'authorizationType': 'NONE'}]
+        with self.assertRaises(expected):
+            next(Public(obj).audit())


### PR DESCRIPTION
Addresses https://github.com/Skyscanner/LambdaGuard/issues/13

LambdaGuard will now check each API Gateway method to see if at least one of them has API Key required or an Authorization Type set before flagging the gateway as public.