### PR TITLE
Run as auditor and use get-function-configuration

### DIFF
--- a/lambdaguard/security/LambdaWrite.py
+++ b/lambdaguard/security/LambdaWrite.py
@@ -100,7 +100,13 @@ class LambdaWrite:
             return StopIteration
         if 'Statement' not in policy['Document']:
             return StopIteration
-        for statement in policy['Document']['Statement']:
+
+        if not isinstance(policy['Document']['Statement'], list):
+            statements = [policy['Document']['Statement']]
+        else:
+            statements = policy['Document']['Statement']
+
+        for statement in statements:
             if 'Effect' not in statement:
                 continue  # Unknown
             if statement['Effect'] != 'Allow':

--- a/lambdaguard/utils/cli.py
+++ b/lambdaguard/utils/cli.py
@@ -114,6 +114,12 @@ def parse_args(arguments=''):
         version=__version__,
         help='Display current version'
     )
+    argsParser.add_argument(
+        '-a',
+        '--auditor',
+        action='store_true',
+        help='Run as an auditor - doesn\'t use lambda:GetFunction permission'
+    )
 
     if len(arguments):
         args = argsParser.parse_known_args(arguments.split())[0]


### PR DESCRIPTION
Added the `-a` parameter, which allows running the tool with auditor permissions.
It does not get the function code, and uses `get_function_configuration` instead of `get_function`.
Also, fixes statement bug to handle case of statement being an object and not a list.

Resolves https://github.com/Skyscanner/LambdaGuard/issues/16
Resolves https://github.com/Skyscanner/LambdaGuard/issues/15