### PR TITLE
Adding checks on some Lambda fields

### DIFF
--- a/lambdaguard/core/Lambda.py
+++ b/lambdaguard/core/Lambda.py
@@ -192,9 +192,7 @@ class Lambda(AWS):
             debug(self.arn.full)
 
     def report(self):
-
         ret = {
-            
             'name': self.arn.resource,
             'description': self.description,
             'region': self.arn.region,
@@ -210,10 +208,8 @@ class Lambda(AWS):
             'triggers': self.triggers,
             'resources': self.resources,
             'security': self.security,
-            'role':""
+            'role': ""
         }
-
-       
 
         if self.policy:
             ret['policy']['function'] = self.policy
@@ -221,13 +217,11 @@ class Lambda(AWS):
             if self.role.arn:
                 ret['role'] = self.role.arn.full
             if self.role.policy:
-                ret['policy']['role'] = self.role.policy    
+                ret['policy']['role'] = self.role.policy
         if self.arn:
             ret['arn'] = self.arn.full
-            
-
-       
         if self.kms:
             ret['kms'] = self.kms.arn.full
             ret['policy']['kms'] = self.kms.policies
+
         return ret

--- a/lambdaguard/security/Scan.py
+++ b/lambdaguard/security/Scan.py
@@ -87,18 +87,24 @@ class Scan:
                         self.track(self.report['arn'], _)
 
         # Audit Execution role policy
-        if not len(self.report['policy']['role']['policies']):
-            self.track(self.report['arn'], {
-                'level': 'info',
-                'text': 'Execution Role policy is not defined'
-            })
+       
+        if self.report['policy']['role'] != "":
+            if not len(self.report['policy']['role']['policies']):
+                self.track(self.report['arn'], {
+                    'level': 'info',
+                    'text': 'Execution Role policy is not defined'
+                })
+            else:
+                for policy in self.report['policy']['role']['policies']:
+                    if 'Statement' in policy['document']:
+                        for statement in policy['document']['Statement']:
+                            for _ in PolicyStatement(statement, policy=policy).audit():
+                                self.track(self.report['role'], _)
         else:
-            for policy in self.report['policy']['role']['policies']:
-                if 'Statement' in policy['document']:
-                    for statement in policy['document']['Statement']:
-                        for _ in PolicyStatement(statement, policy=policy).audit():
-                            self.track(self.report['role'], _)
-
+            self.track(self.report['arn'], {
+                    'level': 'info',
+                    'text': 'Execution Role policy is not defined'
+                })
         # Audit KMS
         if 'kms' in self.report:
             self.item = KMS(

--- a/lambdaguard/visibility/HTMLReport.py
+++ b/lambdaguard/visibility/HTMLReport.py
@@ -161,23 +161,29 @@ class HTMLReport:
                 funcvuln_html.append(ret)
 
             layers = []
-            for layer in func['layers']:
-                layers.append(f"{layer['arn']} ({layer['description']})")
-                layer.update({'runtime': func['runtime']})
-                if layer not in all_layers:
-                    all_layers.append(layer)
+            if func['layers']:
+                for layer in func['layers']:
+                    layers.append(f"{layer['arn']} ({layer['description']})")
+                    layer.update({'runtime': func['runtime']})
+                    if layer not in all_layers:
+                        all_layers.append(layer)
 
             html = func_html_template
             html = html.replace('{index}', idx)
             html = html.replace('{arn}', func['arn'])
             html = html.replace('{name}', func['name'])
-            html = html.replace('{description}', func['description'])
+            if func['description']:
+                html = html.replace('{description}', func['description'])
             html = html.replace('{region}', func['region'])
-            html = html.replace('{runtime}', func['runtime'])
-            html = html.replace('{handler}', func['handler'])
-            html = html.replace('{role}', func['role'])
+            if func['runtime']:
+                html = html.replace('{runtime}', func['runtime'])
+            if func['handler']:
+                html = html.replace('{handler}', func['handler'])
+            if func['role'] != "":
+                html = html.replace('{role}', func['role'])
             html = html.replace('{layers}', self.txt2html('\n'.join(layers)))
-            html = html.replace('{layers_count}', str(len(func['layers'])))
+            if func['layers']:
+                html = html.replace('{layers_count}', str(len(func['layers'])))
             html = html.replace('{triggers}', self.txt2html(', '.join(func['triggers']['services'])))
             html = html.replace('{triggers_count}', str(len(func['triggers']['services'])))
             html = html.replace('{resources}', self.txt2html(', '.join(func['resources']['services'])))

--- a/lambdaguard/visibility/Statistics.py
+++ b/lambdaguard/visibility/Statistics.py
@@ -52,10 +52,13 @@ class Statistics:
         Parses Lambda report and automatically extracts and
         tracks statistics.
         '''
+        
         self.statistics['lambdas'] += 1
-        self.statistics['layers'] += len(report['layers'])
+        if report['layers']:
+            self.statistics['layers'] += len(report['layers'])
         self.track('regions', report['region'])
         self.track('runtimes', report['runtime'])
+
         for idx in ['triggers', 'resources']:
             for arn in report[idx]['items']:
                 if arn == '*':

--- a/lambdaguard/visibility/Statistics.py
+++ b/lambdaguard/visibility/Statistics.py
@@ -52,7 +52,6 @@ class Statistics:
         Parses Lambda report and automatically extracts and
         tracks statistics.
         '''
-        
         self.statistics['lambdas'] += 1
         if report['layers']:
             self.statistics['layers'] += len(report['layers'])


### PR DESCRIPTION
Due a missing good configuration in Lambda, There are a problem in b118877 commit version. This missing configuration causes the following error:
'role': self.role.arn.full, AttributeError: 'NoneType' object has no attribute 'arn'

To avoid it, I've changed the creation of the Lambda Object in core/Lambda.py and also how Scan.py is reading this object and how /visibility/Statistics.py and /visibility/HTMLReport.py is creating the report.

Maybe is not the best solution, but for me, works (with a aws account working in b118877 commit version and with the aws account that cause my error.