### PR TITLE
use region arg if FunctionCount in account usage is 0

### DIFF
--- a/lambdaguard/__init__.py
+++ b/lambdaguard/__init__.py
@@ -129,7 +129,9 @@ def run(arguments=''):
     configure_log(args.output)
     usage = get_usage(args)
     verbose(args, f'Loading identity')
-    sts_arn = f'arn:aws:sts:{list(usage.keys())[0]}'
+    used_regions = list(usage.keys())
+    region = used_regions[0] if len(used_regions) else args.region
+    sts_arn = f'arn:aws:sts:{region}'
     identity = STS(sts_arn, args.profile, args.keys[0], args.keys[1])
     if args.verbose:
         for _ in ['UserId', 'Account', 'Arn']:


### PR DESCRIPTION
If the account does not have the right to list the function count (not sure which policy that is) lambda guard crashes with an error because `usage ` is empty.

This small fix reverts to the previous behavior of directly using the region argument in that case.