### PR TITLE
Running LambdaGuard without AWS Profile

### DIFF
--- a/lambdaguard/__init__.py
+++ b/lambdaguard/__init__.py
@@ -61,7 +61,7 @@ def get_regions(args):
     Returns regions as a Python list
     '''
     if not isinstance(args.region, str):
-        raise ValueError(f'No region specified')
+        raise ValueError('No region specified')
     if args.function:
         return [arnparse(args.function).region]
     available = boto3.Session().get_available_regions('lambda')
@@ -69,7 +69,7 @@ def get_regions(args):
         return available
     regions = args.region.split(',')
     if not regions:
-        raise ValueError(f'No region specified')
+        raise ValueError('No region specified')
     for region in regions:
         if region not in available:
             raise ValueError(f'Invalid region "{region}"')
@@ -130,7 +130,7 @@ def run(arguments=''):
     Path(args.output).mkdir(parents=True, exist_ok=True)
     configure_log(args.output)
     usage = get_usage(args)
-    verbose(args, f'Loading identity')
+    verbose(args, 'Loading identity')
     region = list(usage.keys())[0]
     sts_arn = f'arn:aws:sts:{region}'
     identity = STS(sts_arn, args.profile, args.keys[0], args.keys[1])

--- a/lambdaguard/__version__.py
+++ b/lambdaguard/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (2, 4, 1)
+VERSION = (2, 4, 2)
 
 __version__ = ".".join(map(str, VERSION))

--- a/lambdaguard/core/STS.py
+++ b/lambdaguard/core/STS.py
@@ -23,7 +23,7 @@ class STS(AWS):
         super().__init__(arn, profile, access_key_id, secret_access_key)
         self.caller = self.get_caller_identity()
         self.arn = arnparse(self.caller['Arn'])
-        self.acl = ACL(self.caller['Arn'])
+        self.acl = ACL(self.caller['Arn'], profile, access_key_id, secret_access_key)
 
     def get_caller_identity(self):
         '''


### PR DESCRIPTION
Resolves issue #29 

When creating the `ACL` class in `STS`, the `access_key_id` and `secret_access_key` were not being passed, like other objects in this tool.  Once you follow the same pattern and pass them in, you can use the `--keys` attribute again.