### PR TITLE
Use caching for policies and client objects

### DIFF
--- a/lambdaguard/__init__.py
+++ b/lambdaguard/__init__.py
@@ -28,6 +28,7 @@ from lambdaguard.utils.paginator import paginate
 from lambdaguard.visibility.HTMLReport import HTMLReport
 from lambdaguard.visibility.Report import VisibilityReport
 from lambdaguard.visibility.Statistics import Statistics
+from lambdaguard.core.AWS import get_AWS_client
 
 
 def verbose(args, message, end=""):
@@ -42,13 +43,12 @@ def get_client(args):
     """
     Returns a Lambda botocore client
     """
-    return boto3.Session(
-        profile_name=args.profile,
-        aws_access_key_id=args.keys[0],
-        aws_secret_access_key=args.keys[1],
-        region_name=args.region,
-    ).client("lambda")
-
+    return get_AWS_client(
+        args.profile,
+        args.keys[0],
+        args.keys[1],
+        args.region,
+        "lambda")
 
 def get_regions(args):
     """

--- a/lambdaguard/core/AWS.py
+++ b/lambdaguard/core/AWS.py
@@ -12,10 +12,20 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+import functools
 import boto3
 
 from lambdaguard.utils.arnparse import arnparse
 
+@functools.lru_cache()
+def get_AWS_client(profile_name, aws_access_key_id, aws_secret_access_key, region_name, service):
+    session = boto3.Session(profile_name=profile_name)
+    return session.client(
+        service,
+        region_name=region_name,
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+    )
 
 class AWS(object):
     """
@@ -38,10 +48,10 @@ class AWS(object):
         self.info = ""
 
         # AWS connection
-        session = boto3.Session(profile_name=self.profile)
-        self.client = session.client(
+        self.client = get_AWS_client(
+            self.profile,
+            access_key_id,
+            secret_access_key,
+            self.arn.region,
             self.arn.service,
-            region_name=self.arn.region,
-            aws_access_key_id=access_key_id,
-            aws_secret_access_key=secret_access_key,
         )


### PR DESCRIPTION
LambdaGuard can be too slow on projects with a lot of Lambda functions.

This PR cache the role policies and the boto3 client objects. 